### PR TITLE
Standardize all internal SHA references to tagged main branch commit

### DIFF
--- a/.github/actions/build-to-release-branch/README.md
+++ b/.github/actions/build-to-release-branch/README.md
@@ -33,7 +33,7 @@ jobs:
           cache: 'npm'
 
       - name: Merge and build
-        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@2da9227322333e5f3ba18fec7aceabd9f5de365b
+        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@a9a243d6c42fbff4a967d7ce0a6b307bc77251b7 # v0.1.0
         with:
           source_branch: main
           release_branch: release

--- a/.github/workflows/build-and-release-node.yml
+++ b/.github/workflows/build-and-release-node.yml
@@ -56,7 +56,7 @@ jobs:
           cache: 'npm'
 
       - name: Merge and build
-        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@227ebe6ec618d246d3ed6787c3dc2f2e49f2692f
+        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@a9a243d6c42fbff4a967d7ce0a6b307bc77251b7 # v0.1.0
         with:
           source_branch: ${{ inputs.source_branch }}
           release_branch: ${{ inputs.release_branch }}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   release:
     name: "Update release branch"
-    uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@2da9227322333e5f3ba18fec7aceabd9f5de365b
+    uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@a9a243d6c42fbff4a967d7ce0a6b307bc77251b7 # v0.1.0
     with:
       node_version: 22
       source_branch: main

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This repository contains action and workflow definitions which can be used acros
 
 ### Build to Release Branch
 
-The [`build-to-release-branch.yml`](./actions/build-to-release-branch/action.yml) action can be used to compile a source branch into a target releasable branch, committing any built assets which are normally gitignore'd. This release branch can then be tagged for a formalized NPM or Packagist release, or else tracked in composer as a VCS reference.
+The [`build-to-release-branch.yml`](./.github/actions/build-to-release-branch/action.yml) action can be used to compile a source branch into a target releasable branch, committing any built assets which are normally gitignore'd. This release branch can then be tagged for a formalized NPM or Packagist release, or else tracked in composer as a VCS reference.
 
-[View usage instructions here](./actions/build-to-release-branch/)
+[View usage instructions here](./.github/actions/build-to-release-branch/)
 
 ## Complete Workflows
 


### PR DESCRIPTION
It's not clear what the best way to handle tagging on a multi-action repository is, but for consistency with how we manage tags elsewhere, I'd like to update all these SHA references to point to the tagged and released main branch commit.