### PR TITLE
Increment setup-node to v4.4.0

### DIFF
--- a/.github/actions/build-to-release-branch/README.md
+++ b/.github/actions/build-to-release-branch/README.md
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/build-and-release-node.yml
+++ b/.github/workflows/build-and-release-node.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ inputs.node_version }}
           cache: 'npm'


### PR DESCRIPTION
Updates setup-node to latest

Will need to tag a 0.1.1 of the main repo and update internal SHA references after merge; would love to know if there's a better way to do this in the future