### PR TITLE
Increment internal SHA references to latest main branch

### DIFF
--- a/.github/actions/build-to-release-branch/README.md
+++ b/.github/actions/build-to-release-branch/README.md
@@ -33,7 +33,7 @@ jobs:
           cache: 'npm'
 
       - name: Merge and build
-        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@a9a243d6c42fbff4a967d7ce0a6b307bc77251b7 # v0.1.0
+        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@bbe801d037b61dd0fa0fcd7d208f6bf54d7ca1fd # v0.1.1
         with:
           source_branch: main
           release_branch: release

--- a/.github/workflows/build-and-release-node.yml
+++ b/.github/workflows/build-and-release-node.yml
@@ -56,7 +56,7 @@ jobs:
           cache: 'npm'
 
       - name: Merge and build
-        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@a9a243d6c42fbff4a967d7ce0a6b307bc77251b7 # v0.1.0
+        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@bbe801d037b61dd0fa0fcd7d208f6bf54d7ca1fd # v0.1.1
         with:
           source_branch: ${{ inputs.source_branch }}
           release_branch: ${{ inputs.release_branch }}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   release:
     name: "Update release branch"
-    uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@a9a243d6c42fbff4a967d7ce0a6b307bc77251b7 # v0.1.0
+    uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@bbe801d037b61dd0fa0fcd7d208f6bf54d7ca1fd # v0.1.1
     with:
       node_version: 22
       source_branch: main


### PR DESCRIPTION
We have a bit of a chicken-and-egg here. We want to use this repo via pinned SHA, [for reasons](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) — and we ideally would have a 1:1 correspondence between a tagged release and a specific SHA we use externally. However, it's not possible to make a commit which also uses that commit's SHA in text within its files, so we'll always have an offset between a release commit and the documentation updates.

With this PR, we have two options

- tag the current `main` branch with `v0.1.1`, so that these references point to a tagged release; but then the tagged commit doesn't actually contain the bump to the internal reference;
- merge this release and tag the merge commit `v0.1.1`, so that a tagged commit contains these bumps

I suppose the main thing this is raising is that the reference _from_ the build-and-release-node workflow _to_ the build-to-release-branch action should probably be a local file reference rather than a through-the-'net SHA. 🤔 