### PR TITLE
Prepare v0.2.0

### DIFF
--- a/.github/workflows/build-and-release-node.yml
+++ b/.github/workflows/build-and-release-node.yml
@@ -56,7 +56,7 @@ jobs:
           cache: 'npm'
 
       - name: Merge and build
-        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@bbe801d037b61dd0fa0fcd7d208f6bf54d7ca1fd # v0.1.1
+        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@14c656f671314aab57e1ebd2dcd1039d9b9564d3
         with:
           source_branch: ${{ inputs.source_branch }}
           release_branch: ${{ inputs.release_branch }}


### PR DESCRIPTION
There's a chicken-and-egg scenario here, where the tag, README recommended SHA and latest appropriate commit for the internal reference to the build-to-release-branch action will always be out of sync since they need to be real commit references. You can't do a "relative" path lookup when depending on an action via URL repo path, unfortunately, at least not per my testing.

The better approach long-term may be to fold the `build-to-release-branch` action into the workflow, rather than having it be standalone; but for now, we have a one-commit lag between the latest `main` branch commit that we want to reference for the new tag, and the commit that we'll actually merge and tag.