### PR TITLE
Update README example SHAs for latest release

### DIFF
--- a/.github/actions/build-to-release-branch/README.md
+++ b/.github/actions/build-to-release-branch/README.md
@@ -24,16 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out project
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout # See note below on pinning SHAs.
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - name: Merge and build
-        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@bbe801d037b61dd0fa0fcd7d208f6bf54d7ca1fd # v0.1.1
+        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@04c32a93e52ae987095f144105745a501d6207c8 # v0.2.0
         with:
           source_branch: main
           release_branch: release

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ concurrency:
 jobs:
   release:
     name: "Update release branch"
-    uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@bbe801d037b61dd0fa0fcd7d208f6bf54d7ca1fd # v0.1.1
+    uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@04c32a93e52ae987095f144105745a501d6207c8 # v0.2.0
     with:
-      node_version: 22
+      node_version: 24
       source_branch: main
       release_branch: release
       built_asset_paths: build


### PR DESCRIPTION
What it says in the subject; as per the chicken-and-egg problem in #7 , we need to update these to point to the tagged commit AFTER we make and tag that commit.