### PR TITLE
Add automated block documentation script and workflow

### DIFF
--- a/.document-blocks.json.example
+++ b/.document-blocks.json.example
@@ -1,0 +1,7 @@
+{
+  "blocksDir": "themes/my-theme/blocks",
+  "utilitiesDir": "themes/my-theme/src/utilities",
+  "docsDir": "docs/blocks",
+  "styleRef": "docs/blocks/example-block.md",
+  "coreBlockPrefix": "core-"
+}

--- a/.document-blocks.json.example
+++ b/.document-blocks.json.example
@@ -3,5 +3,8 @@
   "utilitiesDir": "themes/my-theme/src/utilities",
   "docsDir": "docs/blocks",
   "styleRef": "docs/blocks/example-block.md",
-  "coreBlockPrefix": "core-"
+  "coreBlockPrefix": "core-",
+  "model": "claude-haiku-4-5-20251001",
+  "triggerMode": "pr",
+  "docLabel": "generate-docs"
 }

--- a/.github/workflows/document-blocks.yml
+++ b/.github/workflows/document-blocks.yml
@@ -9,6 +9,8 @@ on:
       - staging-built
       - production
       - production-built
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled]
 
 jobs:
   document-blocks:
@@ -17,10 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Full history needed to diff against github.event.before on
-          # multi-commit pushes, and to handle first pushes to new branches.
+          # Full history needed for diffs. head_ref checks out the actual branch
+          # on pull_request events (default checkout is a detached merge commit).
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:
@@ -29,16 +32,40 @@ jobs:
       - name: Detect changed blocks
         id: blocks
         run: |
-          # Read blocksDir from .document-blocks.json, defaulting to "blocks".
           BLOCKS_PATH=$(jq -r '.blocksDir // "blocks"' .document-blocks.json 2>/dev/null || echo "blocks")
+          TRIGGER_MODE=$(jq -r '.triggerMode // "pr"' .document-blocks.json 2>/dev/null || echo "pr")
+          DOC_LABEL=$(jq -r '.docLabel // "generate-docs"' .document-blocks.json 2>/dev/null || echo "generate-docs")
 
-          BEFORE="${{ github.event.before }}"
-          # On a branch's first push, before is the zero SHA — fall back to
-          # diffing against the immediate parent commit instead.
-          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            DIFF=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+          # Skip if the event doesn't match the configured trigger mode.
+          if [ "${{ github.event_name }}" = "push" ] && [ "$TRIGGER_MODE" != "push" ]; then
+            echo "Skipping: configured for PR trigger, not push."
+            echo "blocks=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "$TRIGGER_MODE" != "pr" ]; then
+            echo "Skipping: configured for push trigger, not PR."
+            echo "blocks=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # For labeled events, only proceed if the label matches.
+          if [ "${{ github.event.action }}" = "labeled" ] && [ "${{ github.event.label.name }}" != "$DOC_LABEL" ]; then
+            echo "Skipping: label '${{ github.event.label.name }}' does not match doc label '$DOC_LABEL'."
+            echo "blocks=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Determine diff range based on event type.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            DIFF=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
           else
-            DIFF=$(git diff --name-only "$BEFORE" "${{ github.event.after }}")
+            BEFORE="${{ github.event.before }}"
+            # On a branch's first push, before is the zero SHA — fall back to
+            # diffing against the immediate parent commit instead.
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              DIFF=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+            else
+              DIFF=$(git diff --name-only "$BEFORE" "${{ github.event.after }}")
+            fi
           fi
 
           BLOCKS=$(echo "$DIFF" \

--- a/.github/workflows/document-blocks.yml
+++ b/.github/workflows/document-blocks.yml
@@ -1,0 +1,76 @@
+name: Update block documentation
+
+on:
+  push:
+    branches-ignore:
+      - develop
+      - develop-built
+      - staging
+      - staging-built
+      - production
+      - production-built
+
+jobs:
+  document-blocks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history needed to diff against github.event.before on
+          # multi-commit pushes, and to handle first pushes to new branches.
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Detect changed blocks
+        id: blocks
+        run: |
+          # Read blocksDir from .document-blocks.json, defaulting to "blocks".
+          BLOCKS_PATH=$(jq -r '.blocksDir // "blocks"' .document-blocks.json 2>/dev/null || echo "blocks")
+
+          BEFORE="${{ github.event.before }}"
+          # On a branch's first push, before is the zero SHA — fall back to
+          # diffing against the immediate parent commit instead.
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            DIFF=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+          else
+            DIFF=$(git diff --name-only "$BEFORE" "${{ github.event.after }}")
+          fi
+
+          BLOCKS=$(echo "$DIFF" \
+            | grep "^$BLOCKS_PATH/" \
+            | sed "s|^$BLOCKS_PATH/\([^/]*\)/.*|\1|" \
+            | sort -u \
+            | tr '\n' ' ' \
+            | sed 's/ $//')
+          echo "blocks=$BLOCKS" >> "$GITHUB_OUTPUT"
+          echo "Detected blocks: $BLOCKS"
+
+      - name: Install Claude Code CLI
+        if: steps.blocks.outputs.blocks != ''
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Generate documentation
+        if: steps.blocks.outputs.blocks != ''
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        # Word-splitting of blocks output is intentional here.
+        # shellcheck disable=SC2086
+        run: node scripts/document-blocks.mjs ${{ steps.blocks.outputs.blocks }}
+
+      - name: Commit and push documentation
+        if: steps.blocks.outputs.blocks != ''
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          DOCS_DIR=$(jq -r '.docsDir // "docs/blocks"' .document-blocks.json 2>/dev/null || echo "docs/blocks")
+          git add "$DOCS_DIR"
+          if ! git diff --cached --quiet; then
+            # [skip ci] prevents this commit from re-triggering the workflow.
+            git commit -m "docs: update block documentation [skip ci]"
+            git push
+          fi

--- a/.github/workflows/document-blocks.yml
+++ b/.github/workflows/document-blocks.yml
@@ -95,7 +95,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           DOCS_DIR=$(jq -r '.docsDir // "docs/blocks"' .document-blocks.json 2>/dev/null || echo "docs/blocks")
-          git add "$DOCS_DIR"
+          BLOCKS_PATH=$(jq -r '.blocksDir // "blocks"' .document-blocks.json 2>/dev/null || echo "blocks")
+          git add "$DOCS_DIR" "$BLOCKS_PATH"
           if ! git diff --cached --quiet; then
             # [skip ci] prevents this commit from re-triggering the workflow.
             git commit -m "docs: update block documentation [skip ci]"

--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ jobs:
         npm run build
 ```
 See [.github/workflows/build-and-release-node-basic.yml](./.github/workflows/build-and-release-node.yml) for full usage instructions.
+
+### Block Documentation Workflow
+
+The [`document-blocks.yml`](./.github/workflows/document-blocks.yml) workflow automatically generates markdown documentation for WordPress blocks using Claude Code CLI. On push to a feature branch, it detects which block folders changed, passes their source files to `claude -p`, and commits the generated docs back to the branch.
+
+[View setup and usage instructions here](./document-blocks.md)

--- a/document-blocks.md
+++ b/document-blocks.md
@@ -1,6 +1,6 @@
 # Block Documentation
 
-Automatically generates markdown documentation for WordPress blocks using Claude Code CLI (`claude -p`). By default, documentation is generated when a PR is opened or when a label is applied, and written to `docs/blocks/{block-name}.md`.
+Automatically generates markdown documentation for WordPress blocks using Claude Code CLI (`claude -p`), and adds JSDoc and inline comments directly to block JS files. By default, this runs when a PR is opened or when a label is applied.
 
 ## Setup
 
@@ -87,9 +87,10 @@ npm run document-block carousel
 ## How it works
 
 1. On PR open (or on push, if `triggerMode` is `"push"`), the workflow diffs the changed commits to find which block folders were modified. Applying the configured doc label to an existing PR re-runs generation for all blocks changed in that PR.
-2. For each changed block, the script reads all source files (`block.json`, `edit.js`, `save.js`, `view.js`, `render.php`, deprecations, and optionally a matching utility file) and sends them to `claude -p` with a structured prompt.
-3. The model returns markdown documentation, which is written to `docs/blocks/{block-name}.md`.
-4. The workflow commits and pushes the updated docs with `[skip ci]` to avoid re-triggering itself.
+2. For each changed block, the script reads all source files (`block.json`, `edit.js`, `save.js`, `view.js`, `render.php`, deprecations, and optionally a matching utility file) and runs two tasks in parallel:
+   - Sends the full file set to `claude -p` to generate `docs/blocks/{block-name}.md`.
+   - Sends each JS file individually to `claude -p` to add JSDoc comments and inline explanatory comments, writing the result back in place.
+3. The workflow stages both the docs directory and the blocks directory, commits with `[skip ci]`, and pushes.
 
 ## Requirements
 

--- a/document-blocks.md
+++ b/document-blocks.md
@@ -1,6 +1,6 @@
 # Block Documentation
 
-Automatically generates markdown documentation for WordPress blocks using Claude Code CLI (`claude -p`). Documentation is generated on push to feature branches via GitHub Actions and written to `docs/blocks/{block-name}.md`.
+Automatically generates markdown documentation for WordPress blocks using Claude Code CLI (`claude -p`). By default, documentation is generated when a PR is opened or when a label is applied, and written to `docs/blocks/{block-name}.md`.
 
 ## Setup
 
@@ -22,7 +22,10 @@ Place this file in the project root and set the paths for your theme:
   "utilitiesDir": "themes/my-theme/src/utilities",
   "docsDir": "docs/blocks",
   "styleRef": "docs/blocks/example-block.md",
-  "coreBlockPrefix": "core-"
+  "coreBlockPrefix": "core-",
+  "model": "claude-haiku-4-5-20251001",
+  "triggerMode": "pr",
+  "docLabel": "generate-docs"
 }
 ```
 
@@ -33,6 +36,9 @@ Place this file in the project root and set the paths for your theme:
 | `docsDir` | No | Output directory for generated docs. Defaults to `docs/blocks`. |
 | `styleRef` | No | Path to a markdown file used as a style reference for Claude. Defaults to the first `.md` file found in `docsDir`. |
 | `coreBlockPrefix` | No | Block folder names starting with this prefix that have no `edit.js` or `save.js` are skipped. Defaults to `"core-"`. Set to `""` to disable. |
+| `model` | No | Claude model used for generation. Defaults to `claude-haiku-4-5-20251001`. |
+| `triggerMode` | No | `"pr"` (default) — runs when a PR is opened or the doc label is applied. `"push"` — runs on every push to a non-protected branch. |
+| `docLabel` | No | The PR label that triggers doc generation when `triggerMode` is `"pr"`. Defaults to `"generate-docs"`. |
 
 ### 3. Add repository secret
 
@@ -80,7 +86,7 @@ npm run document-block carousel
 
 ## How it works
 
-1. On push, the workflow diffs the pushed commits against `github.event.before` to find which block folders changed.
+1. On PR open (or on push, if `triggerMode` is `"push"`), the workflow diffs the changed commits to find which block folders were modified. Applying the configured doc label to an existing PR re-runs generation for all blocks changed in that PR.
 2. For each changed block, the script reads all source files (`block.json`, `edit.js`, `save.js`, `view.js`, `render.php`, deprecations, and optionally a matching utility file) and sends them to `claude -p` with a structured prompt.
 3. The model returns markdown documentation, which is written to `docs/blocks/{block-name}.md`.
 4. The workflow commits and pushes the updated docs with `[skip ci]` to avoid re-triggering itself.

--- a/document-blocks.md
+++ b/document-blocks.md
@@ -1,0 +1,92 @@
+# Block Documentation
+
+Automatically generates markdown documentation for WordPress blocks using Claude Code CLI (`claude -p`). Documentation is generated on push to feature branches via GitHub Actions and written to `docs/blocks/{block-name}.md`.
+
+## Setup
+
+### 1. Copy files into the project
+
+```
+scripts/document-blocks.mjs               → scripts/document-blocks.mjs
+.github/workflows/document-blocks.yml     → .github/workflows/document-blocks.yml
+.document-blocks.json.example             → .document-blocks.json  (then edit)
+```
+
+### 2. Configure `.document-blocks.json`
+
+Place this file in the project root and set the paths for your theme:
+
+```json
+{
+  "blocksDir": "themes/my-theme/blocks",
+  "utilitiesDir": "themes/my-theme/src/utilities",
+  "docsDir": "docs/blocks",
+  "styleRef": "docs/blocks/example-block.md",
+  "coreBlockPrefix": "core-"
+}
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `blocksDir` | Yes | Path to the blocks directory, relative to repo root. |
+| `utilitiesDir` | No | Path to a frontend utilities directory. When set, the script also looks for `{block-name}.js` here and includes it in the prompt. |
+| `docsDir` | No | Output directory for generated docs. Defaults to `docs/blocks`. |
+| `styleRef` | No | Path to a markdown file used as a style reference for Claude. Defaults to the first `.md` file found in `docsDir`. |
+| `coreBlockPrefix` | No | Block folder names starting with this prefix that have no `edit.js` or `save.js` are skipped. Defaults to `"core-"`. Set to `""` to disable. |
+
+### 3. Add repository secret
+
+In **Settings → Secrets and variables → Actions**, add:
+
+- `ANTHROPIC_API_KEY` — your Anthropic API key.
+
+### 4. Adjust the branch filter (optional)
+
+The workflow ignores pushes to long-lived branches. Edit the `branches-ignore` list in `.github/workflows/document-blocks.yml` to match the branch names your project uses.
+
+### 5. Create the docs directory
+
+```sh
+mkdir -p docs/blocks
+```
+
+Optionally add a well-documented block's generated output as `docs/blocks/example-block.md` to give Claude a style reference for all subsequent generations.
+
+## Manual use
+
+To generate or regenerate documentation for a specific block:
+
+```sh
+node scripts/document-blocks.mjs <block-name>
+```
+
+To document multiple blocks at once (runs in parallel):
+
+```sh
+node scripts/document-blocks.mjs carousel accordion featured-articles
+```
+
+You can optionally add an npm script to `package.json` for convenience:
+
+```json
+"document-block": "node scripts/document-blocks.mjs"
+```
+
+Then run with:
+
+```sh
+npm run document-block carousel
+```
+
+## How it works
+
+1. On push, the workflow diffs the pushed commits against `github.event.before` to find which block folders changed.
+2. For each changed block, the script reads all source files (`block.json`, `edit.js`, `save.js`, `view.js`, `render.php`, deprecations, and optionally a matching utility file) and sends them to `claude -p` with a structured prompt.
+3. The model returns markdown documentation, which is written to `docs/blocks/{block-name}.md`.
+4. The workflow commits and pushes the updated docs with `[skip ci]` to avoid re-triggering itself.
+
+## Requirements
+
+- [Claude Code CLI](https://claude.ai/code) (`npm install -g @anthropic-ai/claude-code`)
+- Node.js 18+
+- An `ANTHROPIC_API_KEY` environment variable (set automatically in CI via the repository secret)

--- a/scripts/document-blocks.mjs
+++ b/scripts/document-blocks.mjs
@@ -32,6 +32,7 @@ const BLOCKS_DIR = join( ROOT, config.blocksDir ?? 'blocks' );
 const UTILITIES_DIR = config.utilitiesDir ? join( ROOT, config.utilitiesDir ) : null;
 const DOCS_DIR = join( ROOT, config.docsDir ?? 'docs/blocks' );
 const CORE_BLOCK_PREFIX = config.coreBlockPrefix ?? 'core-';
+const MODEL = config.model ?? 'claude-haiku-4-5-20251001';
 
 // Style reference: explicit path in config, or first .md in DOCS_DIR, or none.
 function resolveStyleRef() {
@@ -178,7 +179,7 @@ function runClaude( prompt ) {
 	return new Promise( ( resolve, reject ) => {
 		const proc = spawn(
 			'claude',
-			[ '-p', '--output-format', 'text', '--tools', '' ],
+			[ '-p', '--output-format', 'text', '--tools', '', '--model', MODEL ],
 			{ stdio: [ 'pipe', 'pipe', 'pipe' ] }
 		);
 

--- a/scripts/document-blocks.mjs
+++ b/scripts/document-blocks.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * Generates markdown documentation for one or more WordPress blocks
+ * by feeding block source files to `claude -p`.
+ *
+ * Usage:
+ *   node scripts/document-blocks.mjs [block-name ...]
+ *
+ * With no block names, detects which blocks changed in the last git commit.
+ *
+ * Configuration: place a .document-blocks.json file in the project root.
+ * See block-docs/.document-blocks.json.example for available options.
+ *
+ * Output: {docsDir}/{block-name}.md
+ */
+
+import { spawn, execSync } from 'child_process';
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import { join, resolve, dirname, relative } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname( fileURLToPath( import.meta.url ) );
+const ROOT = resolve( __dirname, '..' );
+
+// Load project config, falling back to defaults.
+const configPath = join( ROOT, '.document-blocks.json' );
+const config = existsSync( configPath )
+	? JSON.parse( readFileSync( configPath, 'utf-8' ) )
+	: {};
+
+const BLOCKS_DIR = join( ROOT, config.blocksDir ?? 'blocks' );
+const UTILITIES_DIR = config.utilitiesDir ? join( ROOT, config.utilitiesDir ) : null;
+const DOCS_DIR = join( ROOT, config.docsDir ?? 'docs/blocks' );
+const CORE_BLOCK_PREFIX = config.coreBlockPrefix ?? 'core-';
+
+// Style reference: explicit path in config, or first .md in DOCS_DIR, or none.
+function resolveStyleRef() {
+	if ( config.styleRef ) {
+		const p = join( ROOT, config.styleRef );
+		return existsSync( p ) ? readFileSync( p, 'utf-8' ) : '';
+	}
+	if ( existsSync( DOCS_DIR ) ) {
+		const first = readdirSync( DOCS_DIR ).find( ( f ) => f.endsWith( '.md' ) );
+		if ( first ) {
+			return readFileSync( join( DOCS_DIR, first ), 'utf-8' );
+		}
+	}
+	return '';
+}
+
+// Files to collect from a block folder, in order.
+const CANDIDATE_FILES = [
+	'block.json',
+	'edit.js',
+	'save.js',
+	'index.js',
+	'view.js',
+	'render.php',
+	'variations.js',
+	'transforms.js',
+	'deprecated.js',
+	'style.scss',
+];
+
+/**
+ * Returns the block names that changed in the most recent git commit.
+ */
+function detectChangedBlocks() {
+	const diff = execSync( 'git diff HEAD~1 --name-only', {
+		cwd: ROOT,
+		encoding: 'utf-8',
+	} );
+
+	// Build a regex from the configured blocks directory path.
+	const blocksRel = relative( ROOT, BLOCKS_DIR ).replace( /\\/g, '/' );
+	const pattern = new RegExp( `^${ blocksRel }/([^/]+)/` );
+
+	const names = new Set();
+	for ( const line of diff.split( '\n' ) ) {
+		const match = line.match( pattern );
+		if ( match ) {
+			names.add( match[ 1 ] );
+		}
+	}
+	return [ ...names ];
+}
+
+/**
+ * Returns true for blocks that are thin core-block overrides (no custom
+ * edit.js or save.js, and whose folder name starts with the configured prefix).
+ * These don't benefit from full AI-generated documentation.
+ */
+function isCoreOverride( blockDir, blockName ) {
+	if ( ! CORE_BLOCK_PREFIX || ! blockName.startsWith( CORE_BLOCK_PREFIX ) ) {
+		return false;
+	}
+	return (
+		! existsSync( join( blockDir, 'edit.js' ) ) &&
+		! existsSync( join( blockDir, 'save.js' ) )
+	);
+}
+
+/**
+ * Reads a file and returns a labelled section string, or empty string if absent.
+ */
+function section( label, filePath ) {
+	if ( ! existsSync( filePath ) ) {
+		return '';
+	}
+	const content = readFileSync( filePath, 'utf-8' ).trim();
+	return `\n### ${ label }\n\`\`\`\n${ content }\n\`\`\`\n`;
+}
+
+/**
+ * Builds the full prompt for a block by assembling its file contents.
+ */
+function buildPrompt( blockName, blockDir, styleRef ) {
+	let files = '';
+
+	for ( const filename of CANDIDATE_FILES ) {
+		files += section( filename, join( blockDir, filename ) );
+	}
+
+	// Deprecations
+	const deprecationsDir = join( blockDir, 'deprecations' );
+	if ( existsSync( deprecationsDir ) ) {
+		for ( const f of readdirSync( deprecationsDir ).sort() ) {
+			if ( f.endsWith( '.js' ) ) {
+				files += section(
+					`deprecations/${ f }`,
+					join( deprecationsDir, f )
+				);
+			}
+		}
+	}
+
+	// Optional: matching frontend utility file (e.g. src/utilities/{block}.js)
+	if ( UTILITIES_DIR ) {
+		const utilityPath = join( UTILITIES_DIR, `${ blockName }.js` );
+		const utilityLabel = join(
+			relative( ROOT, UTILITIES_DIR ),
+			`${ blockName }.js`
+		).replace( /\\/g, '/' );
+		files += section( utilityLabel, utilityPath );
+	}
+
+	const styleRefSection = styleRef
+		? `## Style Reference\n\n${ styleRef }\n\n`
+		: '';
+
+	return `You are documenting a WordPress Gutenberg block.
+
+Analyze the block files below and generate a markdown documentation file.
+
+Follow these rules:
+- ${ styleRef ? 'Use the style reference exactly: same heading structure, table format, and depth.' : 'Use clear markdown with headings, tables where appropriate, and concise prose.' }
+- Cover: what the block does and when to use it, block structure and any parent/child relationships, all attributes with purpose and valid values, editor controls, frontend JS behaviour (if view.js or a utility file exists), CSS custom properties, and deprecation history.
+- Your response must begin with the # heading of the document. Do not write any introductory sentence, explanation, or preamble before the first # heading.
+- Output ONLY the markdown content. No preamble, no code fences wrapping the whole output.
+
+${ styleRefSection }## Block Files: ${ blockName }
+
+${ files }`;
+}
+
+/**
+ * Strips any conversational preamble before the first markdown heading.
+ */
+function stripPreamble( text ) {
+	const index = text.search( /^#/m );
+	return index > 0 ? text.slice( index ) : text;
+}
+
+/**
+ * Calls claude -p with the prompt piped to stdin. Returns a Promise<string>.
+ */
+function runClaude( prompt ) {
+	return new Promise( ( resolve, reject ) => {
+		const proc = spawn(
+			'claude',
+			[ '-p', '--output-format', 'text', '--tools', '' ],
+			{ stdio: [ 'pipe', 'pipe', 'pipe' ] }
+		);
+
+		let stdout = '';
+		let stderr = '';
+		proc.stdout.on( 'data', ( chunk ) => ( stdout += chunk ) );
+		proc.stderr.on( 'data', ( chunk ) => ( stderr += chunk ) );
+
+		proc.stdin.write( prompt );
+		proc.stdin.end();
+
+		proc.on( 'error', reject );
+		proc.on( 'close', ( code ) => {
+			if ( code !== 0 ) {
+				reject(
+					new Error(
+						`claude exited with status ${ code }:\n${ stderr }`
+					)
+				);
+			} else {
+				resolve( stdout.trim() );
+			}
+		} );
+	} );
+}
+
+/**
+ * Documents a single block. Returns true if a file was written.
+ */
+async function documentBlock( name, styleRef ) {
+	const blockDir = join( BLOCKS_DIR, name );
+
+	if ( ! existsSync( blockDir ) ) {
+		console.warn( `  ⚠  Block folder not found: ${ blockDir }` );
+		return false;
+	}
+
+	if ( isCoreOverride( blockDir, name ) ) {
+		console.log( `  –  Skipping core override: ${ name }` );
+		return false;
+	}
+
+	console.log( `  ·  Documenting ${ name }...` );
+	const prompt = buildPrompt( name, blockDir, styleRef );
+	const markdown = stripPreamble( await runClaude( prompt ) );
+	const outPath = join( DOCS_DIR, `${ name }.md` );
+	writeFileSync( outPath, markdown + '\n' );
+	console.log( `  ✓  Written: ${ relative( ROOT, outPath ) }` );
+	return true;
+}
+
+async function main() {
+	const args = process.argv.slice( 2 );
+	const autoCommit = args.includes( '--auto-commit' );
+	const blockNames = args.filter( ( a ) => ! a.startsWith( '--' ) );
+	const styleRef = resolveStyleRef();
+
+	let namesToDocument = blockNames;
+	if ( namesToDocument.length === 0 ) {
+		console.log( 'No block names provided — detecting from last commit...' );
+		namesToDocument = detectChangedBlocks();
+		if ( namesToDocument.length === 0 ) {
+			console.log( 'No block changes detected in last commit.' );
+			process.exit( 0 );
+		}
+		console.log( `Detected blocks: ${ namesToDocument.join( ', ' ) }` );
+	}
+
+	// Process all blocks in parallel.
+	const results = await Promise.allSettled(
+		namesToDocument.map( ( name ) => documentBlock( name, styleRef ) )
+	);
+
+	const generated = results.filter(
+		( r ) => r.status === 'fulfilled' && r.value === true
+	).length;
+	const failed = results.filter( ( r ) => r.status === 'rejected' );
+
+	failed.forEach( ( r, i ) =>
+		console.error(
+			`  ✗  Failed to document ${ namesToDocument[ i ] }: ${ r.reason?.message }`
+		)
+	);
+	console.log(
+		`\nDone. ${ generated } generated, ${ results.length - generated } skipped/failed.`
+	);
+
+	if ( autoCommit && generated > 0 ) {
+		const docsDir = relative( ROOT, DOCS_DIR );
+		execSync( `git add ${ docsDir }`, { cwd: ROOT } );
+		const hasChanges = execSync( 'git diff --cached --name-only', {
+			cwd: ROOT,
+			encoding: 'utf-8',
+		} ).trim();
+		if ( hasChanges ) {
+			// [skip ci] prevents this commit from re-triggering CI workflows.
+			execSync(
+				'git commit -m "docs: update block documentation [skip ci]"',
+				{ cwd: ROOT }
+			);
+			console.log( '→ Documentation committed.' );
+		}
+	}
+}
+
+main().catch( ( err ) => {
+	console.error( err );
+	process.exit( 1 );
+} );

--- a/scripts/document-blocks.mjs
+++ b/scripts/document-blocks.mjs
@@ -63,6 +63,17 @@ const CANDIDATE_FILES = [
 	'style.scss',
 ];
 
+// JS files eligible for inline annotation (excludes non-JS candidates).
+const JS_FILES = [
+	'edit.js',
+	'save.js',
+	'index.js',
+	'view.js',
+	'variations.js',
+	'transforms.js',
+	'deprecated.js',
+];
+
 /**
  * Returns the block names that changed in the most recent git commit.
  */
@@ -173,6 +184,90 @@ function stripPreamble( text ) {
 }
 
 /**
+ * Strips a wrapping code fence if the model returned one despite instructions.
+ */
+function stripCodeFence( text ) {
+	return text.replace( /^```[^\n]*\n/, '' ).replace( /\n```\s*$/, '' );
+}
+
+/**
+ * Builds the prompt for adding inline JSDoc and explanatory comments to a JS file.
+ */
+function buildAnnotationPrompt( filename, content ) {
+	return `You are adding inline documentation to a WordPress block JavaScript file.
+
+Add a JSDoc comment to every function and method that does not already have one, and add brief inline comments for any non-obvious logic.
+
+Rules:
+- Do NOT change any code, variable names, or logic.
+- Do NOT add comments that merely restate what the code does — only explain the WHY or clarify non-obvious behavior.
+- Preserve all existing comments exactly as they are.
+- If the file already has sufficient documentation and nothing needs to be added, return it unchanged.
+- Your response must begin with the first line of the file. Do not write any introductory text, preamble, or explanation — not even to say the file needs no changes.
+- Output ONLY the file content. No code fences wrapping the whole output.
+
+### ${ filename }
+\`\`\`
+${ content }
+\`\`\``;
+}
+
+/**
+ * Annotates all JS files in a block folder with JSDoc and inline comments.
+ */
+async function annotateBlockFiles( blockName, blockDir ) {
+	const candidates = [];
+
+	for ( const filename of JS_FILES ) {
+		const filePath = join( blockDir, filename );
+		if ( existsSync( filePath ) ) {
+			candidates.push( { filename, filePath } );
+		}
+	}
+
+	const deprecationsDir = join( blockDir, 'deprecations' );
+	if ( existsSync( deprecationsDir ) ) {
+		for ( const f of readdirSync( deprecationsDir ).sort() ) {
+			if ( f.endsWith( '.js' ) ) {
+				candidates.push( {
+					filename: `deprecations/${ f }`,
+					filePath: join( deprecationsDir, f ),
+				} );
+			}
+		}
+	}
+
+	if ( UTILITIES_DIR ) {
+		const utilityPath = join( UTILITIES_DIR, `${ blockName }.js` );
+		if ( existsSync( utilityPath ) ) {
+			const utilityLabel = join(
+				relative( ROOT, UTILITIES_DIR ),
+				`${ blockName }.js`
+			).replace( /\\/g, '/' );
+			candidates.push( { filename: utilityLabel, filePath: utilityPath } );
+		}
+	}
+
+	const results = await Promise.allSettled(
+		candidates.map( async ( { filename, filePath } ) => {
+			const content = readFileSync( filePath, 'utf-8' ).trim();
+			const prompt = buildAnnotationPrompt( filename, content );
+			const annotated = stripCodeFence( await runClaude( prompt ) );
+			writeFileSync( filePath, annotated + '\n' );
+			console.log( `  ✓  Annotated: ${ relative( ROOT, filePath ) }` );
+		} )
+	);
+
+	results
+		.filter( ( r ) => r.status === 'rejected' )
+		.forEach( ( r, i ) =>
+			console.error(
+				`  ✗  Failed to annotate ${ candidates[ i ].filename }: ${ r.reason?.message }`
+			)
+		);
+}
+
+/**
  * Calls claude -p with the prompt piped to stdin. Returns a Promise<string>.
  */
 function runClaude( prompt ) {
@@ -223,8 +318,10 @@ async function documentBlock( name, styleRef ) {
 	}
 
 	console.log( `  ·  Documenting ${ name }...` );
-	const prompt = buildPrompt( name, blockDir, styleRef );
-	const markdown = stripPreamble( await runClaude( prompt ) );
+	const [ markdown ] = await Promise.all( [
+		runClaude( buildPrompt( name, blockDir, styleRef ) ).then( stripPreamble ),
+		annotateBlockFiles( name, blockDir ),
+	] );
 	const outPath = join( DOCS_DIR, `${ name }.md` );
 	writeFileSync( outPath, markdown + '\n' );
 	console.log( `  ✓  Written: ${ relative( ROOT, outPath ) }` );
@@ -269,7 +366,8 @@ async function main() {
 
 	if ( autoCommit && generated > 0 ) {
 		const docsDir = relative( ROOT, DOCS_DIR );
-		execSync( `git add ${ docsDir }`, { cwd: ROOT } );
+		const blocksDir = relative( ROOT, BLOCKS_DIR );
+		execSync( `git add ${ docsDir } ${ blocksDir }`, { cwd: ROOT } );
 		const hasChanges = execSync( 'git diff --cached --name-only', {
 			cwd: ROOT,
 			encoding: 'utf-8',


### PR DESCRIPTION
This PR adds automated block documentation scripts that can be added to any project to automate AI documentation of blocks. 

- Adds an automated documentation script
- Includes per-project json settings file
- Includes a document-blocks.md file with setup steps
- Includes a GH action that can run on all pushes to feature branches OR on PR creation and when a label is applied to a PR. This action will run the documentation script to update docs when changes are made to blocks
- Updates the readme to describe the new workflow