### PR TITLE
Update example SHAs to v0.3.0

### DIFF
--- a/.github/actions/build-to-release-branch/README.md
+++ b/.github/actions/build-to-release-branch/README.md
@@ -33,7 +33,7 @@ jobs:
           cache: 'npm'
 
       - name: Merge and build
-        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@04c32a93e52ae987095f144105745a501d6207c8 # v0.2.0
+        uses: humanmade/hm-github-actions/.github/actions/build-to-release-branch@fabf2b583b046cca2cccffa99d5a3cd83c487e4f # v0.3.0
         with:
           source_branch: main
           release_branch: release

--- a/.github/actions/resolve-composer-lock-conflict/README.md
+++ b/.github/actions/resolve-composer-lock-conflict/README.md
@@ -39,7 +39,7 @@ jobs:
           tools: composer
 
       - name: Resolve conflict
-        uses: humanmade/hm-github-actions/.github/actions/resolve-composer-lock-conflict@4d2c658bfd7f5c6b21f1d022322bddf26899b033 # v0.2.0
+        uses: humanmade/hm-github-actions/.github/actions/resolve-composer-lock-conflict@fabf2b583b046cca2cccffa99d5a3cd83c487e4f # v0.3.0
         with:
           base_branch: ${{ github.base_ref }}
           head_branch: ${{ github.head_ref }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Resolve composer.lock content-hash conflict
         if: steps.syncdev.outputs.PULL_REQUEST_NUMBER
-        uses: humanmade/hm-github-actions/.github/actions/resolve-composer-lock-conflict@4d2c658bfd7f5c6b21f1d022322bddf26899b033 # v0.2.0
+        uses: humanmade/hm-github-actions/.github/actions/resolve-composer-lock-conflict@fabf2b583b046cca2cccffa99d5a3cd83c487e4f # v0.3.0
         with:
           base_branch: dev
           head_branch: ${{ steps.sync-pr.outputs.branch }}

--- a/.github/actions/sync-branches/README.md
+++ b/.github/actions/sync-branches/README.md
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Create sync PR
         id: syncdev
-        uses: humanmade/hm-github-actions/.github/actions/sync-branches@4d2c658bfd7f5c6b21f1d022322bddf26899b033 # v0.2.0
+        uses: humanmade/hm-github-actions/.github/actions/sync-branches@fabf2b583b046cca2cccffa99d5a3cd83c487e4f # v0.3.0
         with:
           from_branch: ${{ github.head_ref }}
           to_branch: dev

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ concurrency:
 jobs:
   release:
     name: "Update release branch"
-    uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@04c32a93e52ae987095f144105745a501d6207c8 # v0.2.0
+    uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@fabf2b583b046cca2cccffa99d5a3cd83c487e4f # v0.3.0
     with:
       node_version: 24
       source_branch: main
@@ -77,7 +77,7 @@ concurrency:
 jobs:
   resolve-lock:
     name: "Resolve composer.lock content-hash conflict"
-    uses: humanmade/hm-github-actions/.github/workflows/resolve-composer-lock-conflict.yml@4d2c658bfd7f5c6b21f1d022322bddf26899b033 # v0.2.0
+    uses: humanmade/hm-github-actions/.github/workflows/resolve-composer-lock-conflict.yml@fabf2b583b046cca2cccffa99d5a3cd83c487e4f # v0.3.0
     with:
       base_branch: ${{ github.base_ref }}
       head_branch: ${{ github.head_ref }}


### PR DESCRIPTION
As noted in the PR #10 description, updating pinned SHA references in all READMEs to point to the v0.3.0 release commit (`fabf2b583b046cca2cccffa99d5a3cd83c487e4f`).

Follows the same pattern as #8 (v0.2.0 README update).

## Changes

- `README.md` — both workflow usage examples updated
- `.github/actions/build-to-release-branch/README.md`
- `.github/actions/resolve-composer-lock-conflict/README.md` (2 occurrences)
- `.github/actions/sync-branches/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)