### PR TITLE
Gate composer.lock auto-resolve on install --dry-run

### DIFF
--- a/.github/actions/resolve-composer-lock-conflict/README.md
+++ b/.github/actions/resolve-composer-lock-conflict/README.md
@@ -6,6 +6,7 @@ The action exits without modifying the branch when:
 - There are no conflicts (nothing to do).
 - `composer.json` is also conflicted — a human must resolve it first.
 - `composer.lock` has conflicts beyond the `content-hash` line (package-level changes require human review).
+- The regenerated lock fails `composer install --dry-run` against the merged `composer.json` (a final safety gate before pushing).
 
 The caller is responsible for ensuring the job token can push to `head_branch`. For `pull_request` events from forks, the default `GITHUB_TOKEN` is read-only and the push step will fail; use `pull_request_target` with the usual caveats if fork support is required.
 

--- a/.github/actions/resolve-composer-lock-conflict/action.yml
+++ b/.github/actions/resolve-composer-lock-conflict/action.yml
@@ -102,6 +102,16 @@ runs:
         # match the now-merged composer.json.
         git checkout --ours "$LOCK_PATH"
         ( cd "$WD" && composer update --lock --no-scripts --no-install --no-interaction )
+
+        # Verify the regenerated lock is actually installable against the merged
+        # composer.json. Guards against the case where the package-level diff
+        # check passed but the resolver still disagrees with the merged constraints.
+        if ! ( cd "$WD" && composer install --dry-run --no-scripts --no-interaction ); then
+          echo "Regenerated composer.lock is not installable against the merged composer.json — manual resolution required."
+          git merge --abort 2>/dev/null || true
+          exit 0
+        fi
+
         git add "$LOCK_PATH"
         git commit -m "${{ inputs.commit_message }}"
         git push origin "HEAD:${{ inputs.head_branch }}"

--- a/.github/workflows/resolve-composer-lock-conflict.yml
+++ b/.github/workflows/resolve-composer-lock-conflict.yml
@@ -57,7 +57,7 @@ jobs:
           tools: composer
 
       - name: Resolve conflict
-        uses: humanmade/hm-github-actions/.github/actions/resolve-composer-lock-conflict@4d2c658bfd7f5c6b21f1d022322bddf26899b033 # v0.2.0
+        uses: humanmade/hm-github-actions/.github/actions/resolve-composer-lock-conflict@fabf2b583b046cca2cccffa99d5a3cd83c487e4f # v0.3.0
         with:
           base_branch: ${{ inputs.base_branch }}
           head_branch: ${{ inputs.head_branch }}


### PR DESCRIPTION
## Summary
- After regenerating the `composer.lock` content-hash, run `composer install --dry-run` against the merged `composer.json` before pushing.
- If the dry-run fails, bail out the same way the other safety checks do — leaving the conflict for a human.
- Document the new bail-out condition in the action README.

## Why
The existing checks (composer.json not conflicted; lock differs only on the content-hash line) catch the common shape of this conflict, but they don't guarantee the resolver will agree with the *merged* constraints once `composer.json` is combined. The dry-run is a cheap, side-effect-free final gate that closes that gap and matches the trusted check teams already run locally.

## Test plan
- [ ] Trigger the action on a PR with a pure content-hash conflict — confirm it still auto-resolves and pushes.
- [ ] Trigger on a PR where the merged composer.json introduces a constraint the lock can't satisfy — confirm the dry-run fails and the action exits without pushing.
- [ ] Trigger on a PR with no composer conflict — confirm the early no-op path still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)