### PR TITLE
Update README example SHA to v0.4.0

### DIFF
--- a/.github/actions/resolve-composer-lock-conflict/README.md
+++ b/.github/actions/resolve-composer-lock-conflict/README.md
@@ -40,7 +40,7 @@ jobs:
           tools: composer
 
       - name: Resolve conflict
-        uses: humanmade/hm-github-actions/.github/actions/resolve-composer-lock-conflict@fabf2b583b046cca2cccffa99d5a3cd83c487e4f # v0.3.0
+        uses: humanmade/hm-github-actions/.github/actions/resolve-composer-lock-conflict@1926fac5ec904aef6167fa3ba54477b0d9324462 # v0.4.0
         with:
           base_branch: ${{ github.base_ref }}
           head_branch: ${{ github.head_ref }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Resolve composer.lock content-hash conflict
         if: steps.syncdev.outputs.PULL_REQUEST_NUMBER
-        uses: humanmade/hm-github-actions/.github/actions/resolve-composer-lock-conflict@fabf2b583b046cca2cccffa99d5a3cd83c487e4f # v0.3.0
+        uses: humanmade/hm-github-actions/.github/actions/resolve-composer-lock-conflict@1926fac5ec904aef6167fa3ba54477b0d9324462 # v0.4.0
         with:
           base_branch: dev
           head_branch: ${{ steps.sync-pr.outputs.branch }}


### PR DESCRIPTION
Follow-up to #14: bump the pinned action SHA in both README examples from v0.3.0 to v0.4.0 (1926fac), so callers copying the example get the dry-run gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)