### PR TITLE
Add explain-composer-vcs-bump action

### DIFF
--- a/.github/actions/explain-composer-vcs-bump/README.md
+++ b/.github/actions/explain-composer-vcs-bump/README.md
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Explain composer VCS reference bump
-        uses: humanmade/hm-github-actions/.github/actions/explain-composer-vcs-bump@e23902b9854b30b584643fa96a108d9a4e4c1ed6 # v0.5.0
+        uses: humanmade/hm-github-actions/.github/actions/explain-composer-vcs-bump@70ae190dcc9efa323a3411ca4b25d52015bc1467
         with:
           tracked_packages: |
             wikimedia/shiro-wordpress-theme

--- a/.github/actions/explain-composer-vcs-bump/README.md
+++ b/.github/actions/explain-composer-vcs-bump/README.md
@@ -1,0 +1,56 @@
+# Explain Composer VCS Reference Bump
+
+This action comments on a pull request explaining any change to a tracked composer VCS ("dev-branch") package reference — the kind of dependency tracked in `composer.json` as `dev-release`, `dev-main`, etc., where `composer.lock` pins an exact commit SHA rather than a tagged version. When a PR bumps that pinned SHA, this action posts (or updates) a comment linking to the GitHub compare view between the old and new commit, e.g.:
+
+> `wikimedia/shiro-wordpress-theme` updated from [release#6a15cc7c to release#1acac5bb](https://github.com/wikimedia/shiro-wordpress-theme/compare/6a15cc7ca6f7fc9848672ee8f23f258f9a8496bd...1acac5bb5c5ba89ded1d24dba4d4011f9ec104ad)
+
+The repo URL and branch name are read directly from `composer.lock`'s `source` and `version` fields for each tracked package, so nothing needs to be hardcoded beyond the package names you want to watch. If a tracked package isn't touched by the PR, or was added/removed rather than bumped, it's silently skipped. If a previously-posted comment no longer applies (e.g. the bump was reverted by a later push), the comment is deleted.
+
+The comparison is made against the merge-base of the PR's base and head, not the base branch's live tip — the tip drifts forward as unrelated PRs merge into it, which would otherwise cause false negatives (or, for `dev-branch` packages that both sides happen to resolve to the same current tip, false negatives that look like "nothing changed").
+
+## Usage
+
+Reference this action in a workflow within your project by using a repository action reference. As an example, the below workflow listens for pull request events touching `composer.lock` and comments on any change to a tracked package's VCS reference.
+
+```yml
+name: Explain composer VCS reference bump
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - composer.lock
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  explain-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain composer VCS reference bump
+        uses: humanmade/hm-github-actions/.github/actions/explain-composer-vcs-bump@e23902b9854b30b584643fa96a108d9a4e4c1ed6 # v0.5.0
+        with:
+          tracked_packages: |
+            wikimedia/shiro-wordpress-theme
+            wikimedia/wikimedia-wordpress-security-plugin
+```
+
+> [!NOTE]
+> The action your workflow `uses:` should be referenced by (`@`) a specific Git commit SHA hash for [security reasons](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).
+
+> [!NOTE]
+> This action needs `permissions: issues: write` (not just `pull-requests: write`) — PR conversation comments are served by the Issues REST API regardless of whether the target is an issue or a PR.
+
+> [!NOTE]
+> This action reads the pull request directly from the triggering event context (`github.event.pull_request`) and exits without doing anything if that's not present — it must be run from a `pull_request`-triggered workflow (or a reusable workflow called from one).
+
+### Required Parameters
+
+- `tracked_packages`: Newline-separated list of composer package names to track (e.g. `wikimedia/shiro-wordpress-theme`).
+
+### Optional Parameters
+
+- `working_directory`: Directory containing `composer.lock`. Defaults to the repository root (`.`). Useful for monorepos where Composer is in a subdirectory.

--- a/.github/actions/explain-composer-vcs-bump/README.md
+++ b/.github/actions/explain-composer-vcs-bump/README.md
@@ -1,12 +1,14 @@
 # Explain Composer VCS Reference Bump
 
-This action comments on a pull request explaining any change to a tracked composer VCS ("dev-branch") package reference — the kind of dependency tracked in `composer.json` as `dev-release`, `dev-main`, etc., where `composer.lock` pins an exact commit SHA rather than a tagged version. When a PR bumps that pinned SHA, this action posts (or updates) a comment linking to the GitHub compare view between the old and new commit, e.g.:
+This action comments on a pull request explaining any change to a tracked composer VCS ("dev-branch") package reference (the kind of dependency tracked in `composer.json` as `dev-release`, `dev-main`, etc.), where `composer.lock` pins an exact commit SHA rather than a tagged version. When a PR bumps that pinned SHA, this action posts (or updates) a comment linking to the GitHub compare view between the old and new commit, e.g.:
 
 > `wikimedia/shiro-wordpress-theme` updated from [release#6a15cc7c to release#1acac5bb](https://github.com/wikimedia/shiro-wordpress-theme/compare/6a15cc7ca6f7fc9848672ee8f23f258f9a8496bd...1acac5bb5c5ba89ded1d24dba4d4011f9ec104ad)
 
 The repo URL and branch name are read directly from `composer.lock`'s `source` and `version` fields for each tracked package, so nothing needs to be hardcoded beyond the package names you want to watch. If a tracked package isn't touched by the PR, or was added/removed rather than bumped, it's silently skipped. If a previously-posted comment no longer applies (e.g. the bump was reverted by a later push), the comment is deleted.
 
-The comparison is made against the merge-base of the PR's base and head, not the base branch's live tip — the tip drifts forward as unrelated PRs merge into it, which would otherwise cause false negatives (or, for `dev-branch` packages that both sides happen to resolve to the same current tip, false negatives that look like "nothing changed").
+The comparison is made against the merge-base of the PR's base and head, not the base branch's live tip. We want a dependency change to show up in the PR review even if it also occurs elsewhere.
+
+This action can complement the use of [IonBazan/composer-diff-action](https://github.com/IonBazan/composer-diff-action), which lists the version number changes of composer dependencies in a PR but does not explain the details of a VCS dependency bump.
 
 ## Usage
 
@@ -39,13 +41,13 @@ jobs:
 ```
 
 > [!NOTE]
-> The action your workflow `uses:` should be referenced by (`@`) a specific Git commit SHA hash for [security reasons](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).
+> The action your workflow `uses:` should be referenced by (`@`) a specific Git commit SHA hash both for [security reasons](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and because remote-repo references seem to require this level of specificity.
 
 > [!NOTE]
 > This action needs `permissions: issues: write` (not just `pull-requests: write`) — PR conversation comments are served by the Issues REST API regardless of whether the target is an issue or a PR.
 
 > [!NOTE]
-> This action reads the pull request directly from the triggering event context (`github.event.pull_request`) and exits without doing anything if that's not present — it must be run from a `pull_request`-triggered workflow (or a reusable workflow called from one).
+> This action reads the pull request directly from the triggering event context (`github.event.pull_request`) and exits without doing anything if that's not present. It must be run from a `pull_request`-triggered workflow (or a reusable workflow called from one).
 
 ### Required Parameters
 

--- a/.github/actions/explain-composer-vcs-bump/action.yml
+++ b/.github/actions/explain-composer-vcs-bump/action.yml
@@ -1,0 +1,104 @@
+name: Explain composer VCS reference bump
+description: Comments on a pull request explaining any change to a tracked composer VCS ("dev-branch") package reference, linking to the GitHub compare view between the old and new commit.
+author: Human Made
+
+inputs:
+  tracked_packages:
+    description: Newline-separated list of composer package names to track (e.g. wikimedia/shiro-wordpress-theme).
+    required: true
+  working_directory:
+    description: Directory containing composer.lock. Defaults to repository root.
+    default: .
+    required: false
+
+runs:
+  using: composite
+
+  steps:
+    - name: Check out source code
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+    - name: Compare composer.lock VCS references
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      env:
+        TRACKED_VCS_PACKAGES: ${{ inputs.tracked_packages }}
+        WORKING_DIRECTORY: ${{ inputs.working_directory }}
+      with:
+        script: |
+          const { execFileSync } = require('child_process');
+
+          const pr = context.payload.pull_request;
+          if (!pr) {
+            core.notice('Not running in a pull_request context; skipping.');
+            return;
+          }
+
+          const trackedPackages = process.env.TRACKED_VCS_PACKAGES
+            .split('\n')
+            .map((name) => name.trim())
+            .filter(Boolean);
+
+          const { owner, repo } = context.repo;
+          const lockPath = process.env.WORKING_DIRECTORY === '.'
+            ? 'composer.lock'
+            : `${process.env.WORKING_DIRECTORY}/composer.lock`;
+
+          // pr.base.sha is the base branch's current tip, which drifts forward as
+          // unrelated PRs merge into it. Diff against the merge-base instead, so
+          // this only reflects what this PR itself changed.
+          const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+            owner, repo, basehead: `${pr.base.sha}...${pr.head.sha}`,
+          });
+          const mergeBaseSha = comparison.merge_base_commit.sha;
+
+          execFileSync('git', ['fetch', '--depth=1', 'origin', mergeBaseSha]);
+          execFileSync('git', ['fetch', '--depth=1', 'origin', pr.head.sha]);
+
+          function getPackages(ref) {
+            const content = execFileSync('git', ['show', `${ref}:${lockPath}`]).toString();
+            const lock = JSON.parse(content);
+            const packages = {};
+            for (const pkg of [...(lock.packages || []), ...(lock['packages-dev'] || [])]) {
+              if (pkg.source) packages[pkg.name] = pkg;
+            }
+            return packages;
+          }
+
+          const basePackages = getPackages(mergeBaseSha);
+          const headPackages = getPackages(pr.head.sha);
+
+          // A composer VCS constraint like "dev-release" tracks the tip of the
+          // "release" branch; strip the "dev-" prefix to show that branch name.
+          const branchName = (version) => version.replace(/^dev-/, '');
+
+          const changes = [];
+          for (const name of trackedPackages) {
+            const before = basePackages[name];
+            const after = headPackages[name];
+            if (!before || !after || before.source.reference === after.source.reference) continue;
+
+            const repoUrl = after.source.url.replace(/\.git$/, '');
+            const compareUrl = `${repoUrl}/compare/${before.source.reference}...${after.source.reference}`;
+            const beforeLabel = `${branchName(before.version)}#${before.source.reference.slice(0, 8)}`;
+            const afterLabel = `${branchName(after.version)}#${after.source.reference.slice(0, 8)}`;
+            changes.push(`- \`${name}\` updated from [${beforeLabel} to ${afterLabel}](${compareUrl})`);
+          }
+
+          const marker = '<!-- explain-composer-vcs-bump -->';
+          const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: pr.number });
+          const existing = comments.find((c) => c.body && c.body.includes(marker));
+
+          if (changes.length === 0) {
+            if (existing) {
+              await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+            }
+            return;
+          }
+
+          const body = `${marker}\n### Composer VCS reference changes\n\n${changes.join('\n')}`;
+
+          if (existing) {
+            await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+          } else {
+            await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
+          }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ The [`sync-branches`](./.github/actions/sync-branches/action.yml) action creates
 
 [View usage instructions here](./.github/actions/sync-branches/)
 
+### Explain Composer VCS Reference Bump
+
+The [`explain-composer-vcs-bump`](./.github/actions/explain-composer-vcs-bump/action.yml) action comments on a pull request explaining any change to a tracked composer VCS ("dev-branch") package reference — e.g. a `composer.json` dependency pinned as `dev-release` — linking to the GitHub compare view between the old and new commit.
+
+[View usage instructions here](./.github/actions/explain-composer-vcs-bump/)
+
 ## Complete Workflows
 
 ### Node.js Build-and-Release Workflow


### PR DESCRIPTION
Prototyped on another project to make it easier to inspect the delta between two SHAs when updating a VCS dependency. This type of change tends to get "rubber-stamped" through without review, when we should be verifying that the diff represents the expected upstream change.

<img width="884" height="193" alt="image" src="https://github.com/user-attachments/assets/03147cb4-9f78-4025-a21d-f79a0cab90d1" />
